### PR TITLE
import HeatMap from ant-design/plots

### DIFF
--- a/Maps.fs
+++ b/Maps.fs
@@ -7,7 +7,7 @@ type DotMapBuilder() =
     inherit ChartBuilder(import "DotMap" "@ant-design/maps")
     
 type HeatMapBuilder() =
-    inherit ChartBuilder(import "HeatMap" "@ant-design/maps")
+    inherit ChartBuilder(import "HeatMap" "@ant-design/plots")
     
 type GridMapBuilder() =
     inherit ChartBuilder(import "GridMap" "@ant-design/maps")


### PR DESCRIPTION
Removing a runtime error and importing HeatMap from ant-design/plots instead of ant-design/maps https://charts.ant.design/en/examples/heatmap/basic#basic