### PR TITLE
adding femto support

### DIFF
--- a/Charts.fs
+++ b/Charts.fs
@@ -2,6 +2,7 @@ module Fable.Builders.AntDesignCharts.Charts
 
 open Core
 open Fable.Core.JsInterop
+open Fable.Builders.Common
 
 // Plots
 type AreaBuilder() =
@@ -75,7 +76,9 @@ type WaterfallBuilder() =
     
 type WordCloudBuilder() =
     inherit ChartBuilder(import "WordCloud" "@ant-design/charts")
-    
+    [<CustomOperation("wordField")>] member inline _.wordField (x: DSLElement, v: string) = x.attr "wordField" v
+    [<CustomOperation("weightField")>] member inline _.weightField (x: DSLElement, v: string) = x.attr "weightField" v
+  
 type SunburstBuilder() =
     inherit ChartBuilder(import "Sunburst" "@ant-design/charts")
     

--- a/Core.fs
+++ b/Core.fs
@@ -2,6 +2,7 @@ namespace Fable.Builders.AntDesignCharts
 
 open Fable.Builders.Common
 open Fable.Core
+open System
 
 [<AutoOpen>]
 module Core =
@@ -18,7 +19,7 @@ module Core =
         [<CustomOperation("autoFit")>] member inline _.autoFit (x: DSLElement, v: bool) = x.attr "autoFit" v
         [<CustomOperation("padding")>] member inline _.padding (x: DSLElement, v: int list) = x.attr "padding" v
         [<CustomOperation("appendPadding")>] member inline _.appendPadding (x: DSLElement, v: int list) = x.attr "appendPadding" v
-        [<CustomOperation("renderer")>] member inline _.renderer (x: DSLElement, v: bool) = x.attr "renderer" v
+        [<CustomOperation("renderer")>] member inline _.renderer (x: DSLElement, v: ChartRendered) = x.attr "renderer" v
         [<CustomOperation("pixelRatio")>] member inline _.pixelRatio (x: DSLElement, v: float) = x.attr "pixelRatio" v
         [<CustomOperation("limitInPlot")>] member inline _.limitInPlot (x: DSLElement, v: bool) = x.attr "limitInPlot" v
         [<CustomOperation("locale")>] member inline _.locale (x: DSLElement, v: string) = x.attr "locale" v
@@ -48,6 +49,14 @@ module Core =
         [<CustomOperation("state")>] member inline _.state (x: DSLElement, v: 'v) = x.attr "state" v
         
         // plot components
+        [<CustomOperation("label")>] member inline _.label (x: DSLElement, v: 'T) = x.attr "label" v
+        [<CustomOperation("legend")>] member inline _.legend (x: DSLElement, v: 'T) = x.attr "legend" v
+        [<CustomOperation("tooltip")>] member inline _.tooltip (x: DSLElement, v: 'T) = x.attr "tooltip" v
+
+        // Geometry Style
+        [<CustomOperation("appendPaddings")>] member inline _.appendPaddings (x: DSLElement, v: int list) = x.attr "appendPadding" (v |> Array.ofList)
+        [<CustomOperation("colorFn")>] member inline _.colorFn (x: DSLElement, v: Func<'T, string>) = x.attr "color" v
+
 //        [<CustomOperation("isRange")>] member inline _.isRange (x: DSLElement, v: bool) = x.attr "isRange" v
 //        [<CustomOperation("isRange")>] member inline _.isRange (x: DSLElement, v: bool) = x.attr "isRange" v
 //        [<CustomOperation("isRange")>] member inline _.isRange (x: DSLElement, v: bool) = x.attr "isRange" v

--- a/Fable.Builders.AntDesignCharts.fsproj
+++ b/Fable.Builders.AntDesignCharts.fsproj
@@ -1,4 +1,5 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -8,13 +9,17 @@
         <PackageIcon>icon.png</PackageIcon>
         <RepositoryUrl>https://github.com/uxsoft/Fable.Builders.AntDesignCharts</RepositoryUrl>
     </PropertyGroup>
-
+    <PropertyGroup>
+        <PackageTags>fsharp;fable;fable-binding;fable-javascript;react</PackageTags>
+        <NpmDependencies>
+            <NpmPackage Name="@ant-design/charts" Version="gte 1.4.2 lt 2.0.0" ResolutionStrategy="Min"/>
+        </NpmDependencies>
+    </PropertyGroup>
     <ItemGroup>
-        <Compile Include="Core.fs" />
-        <Compile Include="Maps.fs" />
-        <Compile Include="Charts.fs" />
-        <Compile Include="Maps.fs" />
-        <Compile Include="AntCharts.fs" />
+        <Compile Include="Core.fs"/>
+        <Compile Include="Charts.fs"/>
+        <Compile Include="Maps.fs"/>
+        <Compile Include="AntCharts.fs"/>
     </ItemGroup>
     <ItemGroup>
         <Content Include="*.fsproj; **\*.fs">

--- a/Maps.fs
+++ b/Maps.fs
@@ -7,8 +7,8 @@ type DotMapBuilder() =
     inherit ChartBuilder(import "DotMap" "@ant-design/maps")
     
 type HeatMapBuilder() =
-    inherit ChartBuilder(import "HeatMap" "@ant-design/plots")
-    
+    inherit ChartBuilder(import "Heatmap" "@ant-design/plots")
+
 type GridMapBuilder() =
     inherit ChartBuilder(import "GridMap" "@ant-design/maps")
     

--- a/README.md
+++ b/README.md
@@ -4,12 +4,21 @@
 
 ## Getting Started
 
+### Manual Installation
+
 ```bash
 dotnet package add Fable.Builders.AntDesignCharts
 ```
 
 ```bash
 yarn add @ant-design/charts
+```
+
+### Installation with Femto
+
+Use [Femto](https://github.com/Zaid-Ajaj/Femto), then it can install everything for you in one go
+```
+femto install Fable.Builders.AntDesignCharts
 ```
 
 ## Usage


### PR DESCRIPTION
It appeared that older versions of antd charts had different names. I added another fix and and femto support in order to minimize similar issues. 
Also, couple of additional props for chart builders have been added.